### PR TITLE
Recommend BlockGroup over SimpleBlock in WebM bytestream spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,6 +230,24 @@
           of an <a def-id="webm-init-segment"></a> is encountered.</li>
       </ol>
 
+      <div class="note">
+        Implementations MAY guess the coded frame presentation duration for
+        SimpleBlocks at the end of a <a def-id="webm-cluster"></a>.
+        Content providers are recommended to use BlockGroups with explicit
+        BlockDurations, instead of SimpleBlocks, for the last block for each
+        track in a <a def-id="webm-cluster"></a> to avoid variance in
+        buffering behavior across implementations.
+      </div>
+
+      <div class="note">
+        Implementations MAY introduce buffering latency for each SimpleBlock
+        encountered in a <a def-id="webm-cluster"></a>, since such a block's
+        coded frame presentation duration may not be determinable until the
+        next block is parsed. To avoid such latency, content providers are
+        recommended to use BlockGroups with explicit BlockDuration instead
+        of SimpleBlocks within a <a def-id="webm-cluster"></a>.
+      </div>
+
       <p>The user agent MUST run the <a def-id="append-decode-error-algorithm"></a> if any of the following conditions are not met:</p>
       <ol>
         <li>The Timecode element MUST appear before any Block &amp; SimpleBlock elements in a <a def-id="webm-cluster"></a>.</li>


### PR DESCRIPTION
PR copied over from https://github.com/w3c/media-source/pull/234

Original author:
+@wolenetz

@wolenetz notes in the PR:
[[
Problems with determining coded frame duration of SimpleBlock frames in WebM have not been alleviated by WebM muxer guidelines (e.g. to use BlockGroups with BlockDurations for the last block in each track in each cluster, to avoid having to guess the duration). Furthermore, low-latency buffering+decoding of webm motivates an additional note to use BlockGroups with explicit BlockDurations instead of SimpleGroups for all blocks in a cluster (so as to not have to wait until the next block for each track to compute the timestamp delta and use it as the duration).

This change adds a couple non-normative notes to the current editors draft of the MSE WebM byte stream format spec.

@jyavenard, @johnsim, @mwatson2, @jernoble, @chcunningham - I would appreciate your review of this pull request.
]]

(I removed the part in that comment on the process to update the specs, resolved in the original PR)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-webm/pull/1.html" title="Last updated on Nov 24, 2020, 1:41 PM UTC (621afcb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-webm/1/a005c35...621afcb.html" title="Last updated on Nov 24, 2020, 1:41 PM UTC (621afcb)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-webm/pull/1.html" title="Last updated on Jul 22, 2024, 1:04 PM UTC (56e0b22)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-webm/1/952fb28...56e0b22.html" title="Last updated on Jul 22, 2024, 1:04 PM UTC (56e0b22)">Diff</a>