### PR TITLE
[Editorial] Refresh xref usage, drop custom script

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,29 +4,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>WebM Byte Stream Format</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-    <script src="https://w3c.github.io/media-source/media-source.js" class="remove"></script>
-    <script class="remove">
-      (function() {
-        var webmContainerSpecDefinitions = {
-          'webm-spec': { fragment: '#webm-guidelines', link_text: 'WebM spec',  },
-          'webm-ebml-header': { fragment: '#ebml-basics', link_text: 'EBML Header',  },
-          'webm-segment': { fragment: '#segment', link_text: 'Segment',  },
-          'webm-info': { fragment: '#segment-information', link_text: 'Segment Information',  },
-          'webm-tracks': { fragment: '#track', link_text: 'Tracks',  },
-          'webm-cues': { fragment: '#cueing-data', link_text: 'Cues',  },
-          'webm-chapters': { fragment: '#chapters', link_text: 'Chapters',  },
-          'webm-cluster': { fragment: '#cluster', link_text: 'Cluster',  },
-          'webm-muxer-guidelines': { fragment: '#muxer-guidelines', link_text: 'WebM Muxer Guidelines',  },
-        };
-
-        var webmByteStreamFormatDefinitions = {
-          'webm-init-segment': { fragment: '#webm-init-segments', link_text: 'WebM initialization segment', },
-        };
-
-        mediaSourceAddDefinitionInfo("webm-container-spec", "https://www.webmproject.org/docs/container/", webmContainerSpecDefinitions);
-        mediaSourceAddDefinitionInfo("webm-byte-stream-format", "", webmByteStreamFormatDefinitions);
-      })();
-    </script>
 
     <script class="remove">
       var respecConfig = {
@@ -50,46 +27,11 @@
       company: "Google Inc.", companyURL: "https://www.google.com/" },
       ],
 
-      mseDefGroupName: "webm-byte-stream-format",
-      mseUnusedGroupNameExcludeList: ["media-source"],
-      mseContributors: [
-        "Chris Cunningham",
-        "Frank Galligan",
-        "Philip Jägenstedt",
-      ],
-
       // name of the WG
       group: "media",
 
-      scheme: "https",
-
-      otherLinks: [{
-      key: 'Repository',
-      data: [{
-          value: 'We are on GitHub',
-          href: 'https://github.com/w3c/mse-byte-stream-format-webm/'
-        }, {
-          value: 'File a bug',
-          href: 'https://github.com/w3c/mse-byte-stream-format-webm/issues'
-        }, {
-          value: 'Commit history',
-          href: 'https://github.com/w3c/mse-byte-stream-format-webm/commits/main/index.html'
-        }]
-      },{
-        key: 'Mailing list',
-        data: [{
-          value: 'public-media-wg@w3.org',
-          href: 'https://lists.w3.org/Archives/Public/public-media-wg/'
-        }]
-      }],
-
-      preProcess: [ mediaSourceAddMainSpecDefinitionInfos, mediaSourcePreProcessor ],
-
-      // Empty definitions for objects declared in the document are here to
-      // prevent error messages from being displayed for references to these objects.
-      definitionMap: {},
-
-      postProcess: [ mediaSourcePostProcessor ],
+      github: "w3c/mse-byte-stream-format-webm",
+      wgPublicList: "public-media-wg",
 
       localBiblio: {
           "VP09CODECSPARAMETERSTRING": {
@@ -98,9 +40,7 @@
               authors: ["Frank Galligan", "Kilroy Hughes", "Thomás Inskip", "David Ronca"],
               publisher: "WebM Project",
           },
-       },
-
-       xref: ["html"]
+       }
       };
     </script>
     <!-- script to register bugs -->
@@ -119,27 +59,28 @@
       table.old-table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
     </style>
   </head>
-  <body>
+  <body data-cite="html media-source">
     <section id="abstract">
-      This specification defines a <a def-id="mse-spec"></a> [[MEDIA-SOURCE]] byte stream format specification based on the WebM container format.
+      This specification defines a [[[MEDIA-SOURCE]]] [[MEDIA-SOURCE]] byte stream format specification based on the WebM container format [[WEBM]].
     </section>
 
     <section id="sotd">
       <p>The working group maintains <a href="https://github.com/w3c/mse-byte-stream-format-webm/issues">a list of all bug reports that the editors have not yet tried to address</a>;
-         there may also be related open bugs in the [[MEDIA-SOURCE]] repository.</p>
+      there may also be related open bugs in the <a href="https://github.com/w3c/media-source">GitHub repository</a>.</p>
       <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should track the <a href="https://github.com/w3c/media-source">GitHub repository</a> and take part in the discussions.</p>
     </section>
 
     <section id="introduction">
       <h2>Introduction</h2>
-      <p>This specification describes a byte stream format based on the WebM container format [[!WEBM]]. It defines the MIME-type parameters used to signal codecs, and provides
-      the necessary format specific definitions for <a def-id="init-segments"></a>, <a def-id="media-segments"></a>, and <a def-id="random-access-points"></a> required by
-      the <a def-id="byte-stream-formats-section"></a> of <a def-id="mse-spec"></a> [[!MEDIA-SOURCE]].</p>
+      <p>This specification describes a byte stream format based on the WebM container format [[WEBM]].</p>
+      <p>It defines the MIME-type parameters used to signal codecs, and provides
+      the necessary format specific definitions for [=initialization segments=], [=media segments=], and [=random access point=] required by
+      the <a data-cite="media-source#byte-stream-formats">Byte Stream Formats section</a> of the [[[MEDIA-SOURCE]]] specification.</p>
     </section>
 
     <section id="webm-mime-parameters">
       <h2>MIME-type parameters</h2>
-      <p>This section specifies the parameters that can be used in the MIME-type passed to <a def-id="isTypeSupported"></a> or <a def-id="addSourceBuffer"></a>.</p>
+      <p>This section specifies the parameters that can be used in the MIME-type passed to {{MediaSource/isTypeSupported()}} or {{MediaSource/addSourceBuffer()}}.</p>
       <dl>
         <dt>codecs</dt>
         <dd>
@@ -203,55 +144,59 @@
 
     <section id="webm-init-segments">
       <h2>Initialization Segments</h2>
-      <p>A WebM <a def-id="init-segment"></a> MUST contain a subset of the elements at the start of a typical WebM file.</p>
+      <p>A WebM [=initialization segment=] MUST contain a subset of the elements at the start of a typical WebM file.</p>
 
-      <p>The user agent MUST run the <a def-id="append-decode-error-algorithm"></a> if any of the following conditions are not met:</p>
+      <p>The user agent MUST run the [=append error=] algorithm if any of the following conditions are not met:</p>
       <ol>
-  <li>The <a def-id="init-segment"></a> MUST start with an <a def-id="webm-ebml-header"></a> element, followed by a <a def-id="webm-segment"></a> header.</li>
-  <li>The size value in the <a def-id="webm-segment"></a> header MUST signal an "unknown size" or contain a value large enough to include the <a def-id="webm-info"></a> and <a def-id="webm-tracks"></a> elements that follow.</li>
-  <li>A <a def-id="webm-info"></a> element and a <a def-id="webm-tracks"></a> element MUST appear, in that order, after the <a def-id="webm-segment"></a> header and before any further <a def-id="webm-ebml-header"></a> or <a def-id="webm-cluster"></a> elements.
+  <li>The [=initialization segment=] MUST start with an <a data-cite="WEBM#ebml-basics">EBML Header</a> element, followed by a <a data-cite="WEBM#segment">Segment</a> header.</li>
+  <li>The size value in the <a data-cite="WEBM#segment">Segment</a> header MUST signal an "unknown size" or contain a value large enough to include the <a data-cite="WEBM#segment-information">Segment Information</a> and <a data-cite="WEBM#track">Track</a> elements that follow.</li>
+  <li>A <a data-cite="WEBM#segment-information">Segment Information</a> element and a <a data-cite="WEBM#track">Track</a> element MUST appear, in that order, after the <a data-cite="WEBM#segment">Segment</a> header and before any further <a data-cite="WEBM#ebml-basics">EBML Header</a> or <a data-cite="WEBM#cluster">Cluster</a> elements.
         </li>
       </ol>
-      <p>The user agent MUST accept and ignore any elements other than an <a def-id="webm-ebml-header"></a> or a <a def-id="webm-cluster"></a> that occur before, in between, or after the <a def-id="webm-info"></a> and
-      <a def-id="webm-tracks"></a> elements.</p>
+      <p>The user agent MUST accept and ignore any elements other than an <a data-cite="WEBM#ebml-basics">EBML Header</a> or a <a data-cite="WEBM#cluster">Cluster</a> that occur before, in between, or after the <a data-cite="WEBM#segment-information">Segment Information</a> and
+      <a data-cite="WEBM#track">Track</a> elements.</p>
 
-      <p>The user agent MUST source attribute values for id, kind, label and language for {{AudioTrack}}, {{VideoTrack}} and
+      <p>The user agent MUST source attribute values for `id`, `kind`, `label` and `language` for {{AudioTrack}}, {{VideoTrack}} and
         {{TextTrack}} objects as described for WebM in the in-band tracks spec [[INBANDTRACKS]].</p>
     </section>
 
     <section id="webm-media-segments">
       <h2>Media Segments</h2>
-      <p>A WebM <a def-id="media-segment"></a> is a single <a def-id="webm-cluster"></a> element.</p>
+      <p>A WebM [=media segment=] is a single <a data-cite="WEBM#cluster">Cluster</a> element.</p>
 
-      <p>The user agent uses the following rules when interpreting content in a <a def-id="webm-cluster"></a>:</p>
+      <p>The user agent uses the following rules when interpreting content in a <a data-cite="WEBM#cluster">Cluster</a>:</p>
       <ol>
-        <li>The TimecodeScale in the <a def-id="webm-init-segment"></a> most recently appended applies to all timestamps in the <a def-id="webm-cluster"></a></li>
-        <li>The Timecode element in the <a def-id="webm-cluster"></a> contains a <a def-id="presentation-timestamp"></a> in TimecodeScale units.</li>
-        <li>The Cluster header MAY contain an "unknown" size value. If it does then the end of the cluster is reached when another <a def-id="webm-cluster"></a> header or an element header that indicates the start
-          of an <a def-id="webm-init-segment"></a> is encountered.</li>
+        <li>The TimecodeScale in the WebM [=initialization segment=] most recently appended applies to all timestamps in the <a data-cite="WEBM#cluster">Cluster</a></li>
+        <li>The Timecode element in the <a data-cite="WEBM#cluster">Cluster</a> contains a [=presentation timestamp=] in TimecodeScale units.</li>
+        <li>The Cluster header MAY contain an "unknown" size value. If it does then the end of the cluster is reached when another <a data-cite="WEBM#cluster">Cluster</a> header or an element header that indicates the start
+          of a WebM [=initialization segment=] is encountered.</li>
       </ol>
 
-      <p>The user agent MUST run the <a def-id="append-decode-error-algorithm"></a> if any of the following conditions are not met:</p>
+      <p>The user agent MUST run the [=append error=] algorithm if any of the following conditions are not met:</p>
       <ol>
-        <li>The Timecode element MUST appear before any Block &amp; SimpleBlock elements in a <a def-id="webm-cluster"></a>.</li>
-        <li>Block &amp; SimpleBlock elements are in time increasing order consistent with the <a def-id="webm-spec"></a>.</li>
-        <li>If the most recent <a def-id="webm-init-segment"></a> describes multiple tracks, then blocks from all the tracks MUST be interleaved in time increasing order. At least one block from all audio and video
+        <li>The Timecode element MUST appear before any Block &amp; SimpleBlock elements in a <a data-cite="WEBM#cluster">Cluster</a>.</li>
+        <li>Block &amp; SimpleBlock elements are in time increasing order consistent with [[WEBM]].</li>
+        <li>If the most recent WebM [=initialization segment=] describes multiple tracks, then blocks from all the tracks MUST be interleaved in time increasing order. At least one block from all audio and video
           tracks MUST be present.</li>
       </ol>
 
-      <p>The user agent MUST accept and ignore <a def-id="webm-cues"></a> or <a def-id="webm-chapters"></a> elements that follow a <a def-id="webm-cluster"></a> element.</p>
+      <p>The user agent MUST accept and ignore <a data-cite="WEBM#cueing-data">Cues</a> or <a data-cite="WEBM#chapters">Chapters</a> elements that follow a <a data-cite="WEBM#cluster">Cluster</a> element.</p>
     </section>
 
     <section id="webm-random-access-points">
       <h2>Random Access Points</h2>
-      <p>Either a SimpleBlock element with its Keyframe flag set, or a BlockGroup element having no ReferenceBlock elements, signals the location of a <a def-id="random-access-point"></a> for that track. The order of multiplexed blocks within a <a def-id="media-segment"></a> MUST conform to the <a def-id="webm-muxer-guidelines"></a>.</p>
+      <p>Either a SimpleBlock element with its Keyframe flag set, or a BlockGroup element having no ReferenceBlock elements, signals the location of a [=random access point=] for that track. The order of multiplexed blocks within a [=media segment=] MUST conform to the <a data-cite="WEBM#muxer-guidelines">WebM Muxer Guidelines</a>.</p>
     </section>
 
     <section id="conformance"></section>
 
     <section id="acknowledgements">
       <h2>Acknowledgments</h2>
-      The editors would like to thank <a def-id="contributors"></a> for their contributions to this specification.
+      The editors would like to thank
+
+      Chris Cunningham,
+      Frank Galligan,
+      and Philip Jägenstedt for their contributions to this specification.
     </section>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
       <h2>Introduction</h2>
       <p>This specification describes a byte stream format based on the WebM container format [[WEBM]].</p>
       <p>It defines the MIME-type parameters used to signal codecs, and provides
-      the necessary format specific definitions for [=initialization segments=], [=media segments=], and [=random access point=] required by
+      the necessary format specific definitions for [=initialization segments=], [=media segments=], and [=random access points=] required by
       the <a data-cite="media-source#byte-stream-formats">Byte Stream Formats section</a> of the [[[MEDIA-SOURCE]]] specification.</p>
     </section>
 


### PR DESCRIPTION
See discussion in https://github.com/w3c/media-source/pull/337#issuecomment-1837837578

Fragment references to WebM Container Guidelines spec need to be done through `data-cite` because the spec is not in the cross-references database (and does not follow usual conventions for definitions).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-webm/pull/5.html" title="Last updated on Dec 5, 2023, 8:59 PM UTC (980d0fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mse-byte-stream-format-webm/5/bae104b...980d0fe.html" title="Last updated on Dec 5, 2023, 8:59 PM UTC (980d0fe)">Diff</a>